### PR TITLE
Changing loop bounds to allow for more modular and expandable code

### DIFF
--- a/Session 2 - Tokenization and Lemmatization of Texts.ipynb
+++ b/Session 2 - Tokenization and Lemmatization of Texts.ipynb
@@ -2009,7 +2009,7 @@
     "# We need to import a special package from CLTK to take care of this.\n",
     "from cltk.stem.latin.j_v import JVReplacer\n",
     "replacer = JVReplacer()\n",
-    "for i in range(12):\n",
+    "for i in range(len(aeneid)):\n",
     "    aeneid[i] = replacer.replace(aeneid[i].lower())\n",
     "print(aeneid[0])\n",
     "\n",
@@ -2051,7 +2051,7 @@
     "aeneid_tokens = []\n",
     "\n",
     "# A for-loop to actually implement the tokenizer\n",
-    "for i in range(12):\n",
+    "for i in range(len(aeneid)):\n",
     "    aeneid_tokens.append(tokenizer.tokenize(aeneid[i]))\n",
     "\n",
     "# Let's see if it worked. You should see the first 100 \"words\" of Book 1 of the Aeneid. \n",
@@ -2154,14 +2154,14 @@
     "lemmatizer = LemmaReplacer('latin')\n",
     "\n",
     "aeneid_lemmata = []\n",
-    "for i in range(12):\n",
+    "for i in range(len(aeneid)):\n",
     "    aeneid_lemmata.append(lemmatizer.lemmatize(aeneid_tokens[i]))\n",
     "print(aeneid_lemmata[0][:50])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
@@ -2280,7 +2280,7 @@
     "files = ll.fileids()\n",
     "vergil_files = [file for file in files if \"vergil\" in file]\n",
     "aeneid_whole = \"\"\n",
-    "for i in range(12):\n",
+    "for i in range(len(aeneid)):\n",
     "    aeneid_whole += ll.raw(vergil_files[i])\n",
     "#print(aeneid_whole)\n",
     "aeneid_clean = preprocess(aeneid_whole)\n",


### PR DESCRIPTION
Just made some small changes where I noticed upper bounds for loops were constants. Changing it to `len(myList)` gets the length of the list. Setting that as the upper bound of those loops makes the code able to be expanded in a simple fashion. You just add to the list and BAM it works without having to change all of those pesky parameters.